### PR TITLE
Fix issue #95 (crash in in-group editing mode)

### DIFF
--- a/src/image_occlusion_enhanced/add.py
+++ b/src/image_occlusion_enhanced/add.py
@@ -273,8 +273,12 @@ class ImgOccAdd(object):
 
     def onAddNotesButton(self, choice, close):
         dialog = self.imgoccedit
+        # If the user is in in-group editing mode (i.e. editing a shape that 
+        # is grouped with other shapes) svgCanvasToString() doesn't work and 
+        # the callback gets called with `None` (might be a bug in svg-edit).
+        # Calling leaveContext() first fixes this.
         dialog.svg_edit.evalWithCallback(
-            "svgCanvas.svgCanvasToString();",
+            "svgCanvas.leaveContext(); svgCanvas.svgCanvasToString();",
             lambda val, choice=choice, close=close: self._onAddNotesButton(choice, close, val))
 
     def _onAddNotesButton(self, choice, close, svg):
@@ -312,8 +316,10 @@ class ImgOccAdd(object):
 
     def onEditNotesButton(self, choice):
         dialog = self.imgoccedit
+        # See the comment above in addNotesButton() about 
+        # the call to `leaveContext()`.
         dialog.svg_edit.evalWithCallback(
-            "svgCanvas.svgCanvasToString();",
+            "svgCanvas.leaveContext(); svgCanvas.svgCanvasToString();",
             lambda val, choice=choice: self._onEditNotesButton(choice, val))
 
     def _onEditNotesButton(self, choice, svg):


### PR DESCRIPTION
#### Description

This fixes this [issue](https://github.com/glutanimate/image-occlusion-enhanced/issues/95).
Note that the crash which the issue is about can occur in more situations than are described there. It doesn't only happen when the user presses `Ctrl+Return` but also when they add cards using the buttons at the bottom (if they are in in-group editing mode). It can not only happen while adding new cards but also when editing existing cards that contain groups of elements.

I fixed it by calling `leaveContext()` before the calls to `svgCanvasToString()` in `add.py`. `leaveContext()` returns from a group context to the normal one. When I inspected the code for `svgCanvasToString()` I found that it actually calls `leaveContext()`, too but it still doesn't work when it isn't called before. So this might be a bug in svg-edit.

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Arch Linux
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
