### PR TITLE
Fix issue #72 (Prompt for confirmation before exiting dialog)

### DIFF
--- a/src/image_occlusion_enhanced/add.py
+++ b/src/image_occlusion_enhanced/add.py
@@ -21,7 +21,7 @@ import tempfile
 
 from aqt.qt import *
 
-from aqt import mw
+from aqt import mw, dialogs
 from aqt.utils import tooltip, showWarning
 
 from .ngen import *
@@ -189,7 +189,7 @@ class ImgOccAdd(object):
         flds = self.mflds
         deck = mw.col.decks.nameOrNone(opref["did"])
 
-        dialog = ImgOccEdit(self, self.ed.parentWindow)
+        dialog = dialogs.open('ImgOccEdit', self, self.ed.parentWindow)
         dialog.setupFields(flds)
         dialog.switchToMode(self.mode)
         self.imgoccedit = dialog
@@ -247,6 +247,11 @@ class ImgOccAdd(object):
                     ioInfo("obsolete_aa", parent=dialog)
                 dialog.showSvgEdit(True)
                 dialog.fitImageCanvas()
+                # The only thing undo does in edit mode is removing all
+                # occlusions. If the undo stack is not empty at the beginning
+                # there will always be a confirmation popup before the user
+                # can close the dialog.
+                dialog.svg_edit.eval("svgCanvas.undoMgr.resetUndoStack()")
 
         dialog.svg_edit.runOnLoaded(onSvgEditLoaded)
         dialog.visible = True

--- a/src/image_occlusion_enhanced/main.py
+++ b/src/image_occlusion_enhanced/main.py
@@ -23,6 +23,7 @@ from anki.lang import _
 from aqt.qt import *
 
 from aqt import mw
+from aqt import dialogs
 from aqt.editor import Editor, EditorWebView
 from aqt.addcards import AddCards
 from aqt.editcurrent import EditCurrent
@@ -35,6 +36,7 @@ from .config import *
 from .add import ImgOccAdd
 from .options import ImgOccOpts
 from .dialogs import ioHelp, ioCritical
+from .editor import ImgOccEdit
 
 logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
@@ -269,3 +271,6 @@ if not ANKI21:
     Reviewer._keyHandler = wrap(Reviewer._keyHandler, newKeyHandler, "before")
 else:
     addHook("reviewStateShortcuts", onReviewerStateShortcuts)
+
+# Set up dialog
+dialogs._dialogs['ImgOccEdit'] = [ImgOccEdit, None]


### PR DESCRIPTION
#### Description
Fixes #72.

The confirmation popup is shown in some cases where I don't think it's necessary. If the user adds occlusions, clicks on one of the buttons to create the cards and then closes the editor dialog they are
prompted for confirmation.
The only way I can think of to prevent this is to reset the svg-edit undo stack when the user clicks on the button, but I'm not sure if that's acceptable.
I changed the way the popup opens from directly calling the constructor to opening it via `aqt.dialogs.open(...)` so it behaves more like the other dialogs in Anki.
I used the `askUser(...)` function from `aqt.utils` to show the popup as you can see in the following screenshot:
![image](https://user-images.githubusercontent.com/12101162/71764376-64b30b80-2ee7-11ea-834f-0ae278772eb9.png)

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
