### PR TITLE
Use double quotes in queries and don't quote the field name individually

### DIFF
--- a/src/image_occlusion_enhanced/nconvert.py
+++ b/src/image_occlusion_enhanced/nconvert.py
@@ -92,7 +92,7 @@ class ImgOccNoteConverter(object):
     def findByNoteId(self, note_id):
         """Search collection for notes with given ID in their omask paths"""
         # need to use omask path because Note ID field is not yet set
-        query = "'%s':'*%s*'" % (self.ioflds['om'], note_id)
+        query = '"%s:*%s*"' % (self.ioflds['om'], note_id)
         logging.debug("query: %s", query)
         res = mw.col.findNotes(query)
         return res

--- a/src/image_occlusion_enhanced/ngen.py
+++ b/src/image_occlusion_enhanced/ngen.py
@@ -233,7 +233,7 @@ class ImgOccNoteGenerator(object):
 
     def _findByNoteId(self, note_id):
         """Search collection for notes with given ID"""
-        query = "'%s':'%s*'" % (self.ioflds['id'], note_id)
+        query = '"%s:%s*"' % (self.ioflds['id'], note_id)
         logging.debug("query %s", query)
         res = mw.col.findNotes(query)
         return res


### PR DESCRIPTION
Fixes #137

#### Description
I don't know if it's intentended that quoting the field name idividually doesn't work anymore.
But quoting the whole string used to work before .24 as well, so there's probably nothing wrong with doing that.

#### Checklist:
- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
  - [x] Anki 2.1.24 (e29d380d) running from source
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
