### PR TITLE
Revert "Change config access"

### DIFF
--- a/src/image_occlusion_enhanced/config.py
+++ b/src/image_occlusion_enhanced/config.py
@@ -77,27 +77,25 @@ def getSyncedConfig():
     # Synced preferences
     if 'imgocc' not in mw.col.conf:
         # create initial configuration
-        mw.col.set_config('imgocc', default_conf_syncd)
+        mw.col.conf['imgocc'] = default_conf_syncd
 
         # upgrade from IO 2.0:
         if 'image_occlusion_conf' in mw.col.conf:
-            old_conf = mw.col.get_config('image_occlusion_conf')
-            conf = mw.col.get_config('imgocc')
-            conf['ofill'] = old_conf['initFill[color]']
-            conf['qfill'] = old_conf['mask_fill_color']
-            mw.col.set_conf('imgocc', conf)
+            old_conf = mw.col.conf['image_occlusion_conf']
+            mw.col.conf['imgocc']['ofill'] = old_conf['initFill[color]']
+            mw.col.conf['imgocc']['qfill'] = old_conf['mask_fill_color']
             # insert other upgrade actions here
+        mw.col.setMod()
 
-    elif mw.col.get_config('imgocc')['version'] < default_conf_syncd['version']:
+    elif mw.col.conf['imgocc']['version'] < default_conf_syncd['version']:
         print("Updating config DB from earlier IO release")
-        conf = mw.col.get_config('imgocc')
         for key in list(default_conf_syncd.keys()):
-            if key not in mw.col.get_config('imgocc'):
-                conf[key] = default_conf_syncd[key]
-        conf['version'] = default_conf_syncd['version']
-        mw.col.set_config('imgocc', conf)
+            if key not in mw.col.conf['imgocc']:
+                mw.col.conf['imgocc'][key] = default_conf_syncd[key]
+        mw.col.conf['imgocc']['version'] = default_conf_syncd['version']
+        mw.col.setMod()
 
-    return mw.col.get_config('imgocc')
+    return mw.col.conf['imgocc']
 
 
 def getLocalConfig():
@@ -106,7 +104,7 @@ def getLocalConfig():
         mw.pm.profile["imgocc"] = default_conf_local
     elif mw.pm.profile['imgocc'].get('version', 0) < default_conf_syncd['version']:
         for key in list(default_conf_local.keys()):
-            if key not in mw.col.get_config('imgocc'):
+            if key not in mw.col.conf['imgocc']:
                 mw.pm.profile["imgocc"][key] = default_conf_local[key]
         mw.pm.profile['imgocc']['version'] = default_conf_local['version']
 
@@ -118,11 +116,9 @@ def getOrCreateModel():
     if not model:
         # create model and set up default field name config
         model = template.add_io_model(mw.col)
-        conf = mw.col.get_config('imgocc')
-        conf['flds'] = default_conf_syncd['flds']
-        mw.col.set_config('imgocc', conf)
+        mw.col.conf['imgocc']['flds'] = default_conf_syncd['flds']
         return model
-    model_version = mw.col.get_config('imgocc')['version']
+    model_version = mw.col.conf['imgocc']['version']
     if model_version < default_conf_syncd['version']:
         return template.update_template(mw.col, model_version)
     return model
@@ -131,7 +127,7 @@ def getOrCreateModel():
 def getModelConfig():
     model = getOrCreateModel()
     mflds = model['flds']
-    ioflds = mw.col.get_config('imgocc')['flds']
+    ioflds = mw.col.conf['imgocc']['flds']
     ioflds_priv = []
     for i in IO_FIDS_PRIV:
         ioflds_priv.append(ioflds[i])

--- a/src/image_occlusion_enhanced/main.py
+++ b/src/image_occlusion_enhanced/main.py
@@ -62,7 +62,7 @@ def onImgOccButton(self, origin=None, image_path=None):
     if io_model:
         io_model_fields = mw.col.models.fieldNames(io_model)
         if "imgocc" in mw.col.conf:
-            dflt_fields = list(mw.col.get_config('imgocc')['flds'].values())
+            dflt_fields = list(mw.col.conf['imgocc']['flds'].values())
         else:
             dflt_fields = list(IO_FLDS.values())
         # note type integrity check

--- a/src/image_occlusion_enhanced/ngen.py
+++ b/src/image_occlusion_enhanced/ngen.py
@@ -68,7 +68,7 @@ class ImgOccNoteGenerator(object):
         self.tags = tags
         self.fields = fields
         self.did = did
-        self.qfill = '#' + mw.col.get_config('imgocc')['qfill']
+        self.qfill = '#' + mw.col.conf['imgocc']['qfill']
         loadConfig(self)
 
     def generateNotes(self):

--- a/src/image_occlusion_enhanced/options.py
+++ b/src/image_occlusion_enhanced/options.py
@@ -323,15 +323,13 @@ class ImgOccOpts(QDialog):
             if not self.lnedit[key].isModified():
                 continue
             name = self.lnedit[key].text()
-            oldname = mw.col.get_config('imgocc')['flds'][key]
+            oldname = mw.col.conf['imgocc']['flds'][key]
             if (name is None or not name.strip() or name == oldname):
                 continue
             fnames = mw.col.models.fieldNames(model)
             if (name in fnames and oldname not in fnames):
                 # case: imported cards, fields not corresponding to config
-                conf = mw.col.get_config('imgocc')
-                conf['flds'][key] = name
-                mw.col.set_config('imgocc', conf)
+                mw.col.conf['imgocc']['flds'][key] = name
                 modified = True
                 continue
             idx = fnames.index(oldname)
@@ -340,9 +338,7 @@ class ImgOccOpts(QDialog):
                 # rename note type fields
                 mw.col.models.renameField(model, fld, name)
                 # update imgocc field-id <-> field-name assignment
-                conf = mw.col.get_config('imgocc')
-                conf['flds'][key] = name
-                mw.col.set_config('imgocc', conf)
+                mw.col.conf['imgocc']['flds'][key] = name
                 modified = True
                 logging.debug("Renamed %s to %s", oldname, name)
         if modified:
@@ -360,16 +356,15 @@ class ImgOccOpts(QDialog):
             return
         if modified and hasattr(mw, "ImgOccEdit"):
             self.resetIoEditor(flds)
-        conf = mw.col.get_config('imgocc')
-        conf['ofill'] = self.ofill
-        conf['qfill'] = self.qfill
-        conf['scol'] = self.scol
-        conf['swidth'] = self.swidth_sel.value()
-        conf['fsize'] = self.fsize_sel.value()
-        conf['font'] = self.font_sel.currentFont().family()
-        conf['skip'] = self.skipped.text().split(',')
-        mw.col.set_config('imgocc', conf)
+        mw.col.conf['imgocc']['ofill'] = self.ofill
+        mw.col.conf['imgocc']['qfill'] = self.qfill
+        mw.col.conf['imgocc']['scol'] = self.scol
+        mw.col.conf['imgocc']['swidth'] = self.swidth_sel.value()
+        mw.col.conf['imgocc']['fsize'] = self.fsize_sel.value()
+        mw.col.conf['imgocc']['font'] = self.font_sel.currentFont().family()
+        mw.col.conf['imgocc']['skip'] = self.skipped.text().split(',')
         mw.pm.profile["imgocc"]["hotkey"] = self.hotkey
+        mw.col.setMod()
         self.close()
 
     def resetIoEditor(self, flds):


### PR DESCRIPTION
Reverts glutanimate/image-occlusion-enhanced#143

Was too happy on the trigger-finger. We need to maintain backwards-compatibility with earlier 2.1 releases. Adoption of 2.1.24+ will take a while, and we can't force hundreds of thousands of users to update to a fairly new and untested release. Will revisit this in the future when 2.1.24+ is more mature, user adoption has progressed, and when we've reevaluated whether we should perhaps even overhaul the config system completely instead.