### PR TITLE
Fix version number

### DIFF
--- a/src/image_occlusion_enhanced/_version.py
+++ b/src/image_occlusion_enhanced/_version.py
@@ -33,4 +33,4 @@
 Version information
 """
 
-__version__ = "v1.3.0-alpha1"
+__version__ = "v1.3.0-alpha6"


### PR DESCRIPTION
#### Description

The version was bumped from `1.3.0-alpha5` to `1.3.0-alpha6`, but `_version.py` changed to `1.3.0-alpha1`.


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
