### PR TITLE
[config.py] Updated deprecated method call.

### DIFF
--- a/src/image_occlusion_enhanced/config.py
+++ b/src/image_occlusion_enhanced/config.py
@@ -134,7 +134,7 @@ def getLocalConfig():
 
 
 def getOrCreateModel():
-    model = mw.col.models.byName(IO_MODEL_NAME)
+    model = mw.col.models.by_name(IO_MODEL_NAME)
     if not model:
         # create model and set up default field name config
         model = template.add_io_model(mw.col)


### PR DESCRIPTION
`byName` is deprecated, and triggers a deprecation warning (at least since Anki 2.1.48), and should be replaced with `by_name`.

#### Description
`byName` method call in the `config.py` file has been appropriately replaced with `by_name`.

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build (2.1.48)
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: NixOS 21.11 unstable
  - [ ] Windows
  - [ ] macOS 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb