### PR TITLE
Ensure working directory is collection.media

### DIFF
--- a/src/image_occlusion_enhanced/ngen.py
+++ b/src/image_occlusion_enhanced/ngen.py
@@ -2,7 +2,7 @@
 
 # Image Occlusion Enhanced Add-on for Anki
 #
-# Copyright (C) 2016-2020  Aristotelis P. <https://glutanimate.com/>
+# Copyright (C) 2016-2022  Aristotelis P. <https://glutanimate.com/>
 # Copyright (C) 2013 Steve AW <https://github.com/steveaw>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -36,10 +36,12 @@ the collection.
 """
 
 import logging
+import os
 
 from aqt.qt import *
 from aqt import mw
 from aqt.utils import tooltip
+from anki.media import media_paths_from_col_path
 from anki.notes import Note
 
 from xml.dom import minidom
@@ -88,6 +90,8 @@ class ImgOccNoteGenerator(object):
         self.did = did
         self.qfill = '#' + mw.col.conf['imgocc']['qfill']
         loadConfig(self)
+        # set working directory to collection.media
+        os.chdir(media_paths_from_col_path(mw.col.path)[0])
 
     def generateNotes(self):
         """Generate new notes"""


### PR DESCRIPTION
#### Description

When running Anki from source, the working directory is in some bazel cache directory. Generated masks therefore end up in the wrong directory.
This change ensures that collection.media is the working directory by using this function:
https://github.com/ankitects/anki/blob/26d40c3a8ef066fd4bb3c023bddcc606f8cdfe51/pylib/anki/media.py#L23

**I did not test this with a binary build.**

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Anki v2.1.50 running from source
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bookworm
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
