### PR TITLE
Add context menu handling for Qt6

### DIFF
--- a/src/image_occlusion_enhanced/main.py
+++ b/src/image_occlusion_enhanced/main.py
@@ -2,7 +2,7 @@
 
 # Image Occlusion Enhanced Add-on for Anki
 #
-# Copyright (C) 2016-2020  Aristotelis P. <https://glutanimate.com/>
+# Copyright (C) 2016-2022  Aristotelis P. <https://glutanimate.com/>
 # Copyright (C) 2012-2015  Tiago Barroso <tmbb@campus.ul.pt>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -39,7 +39,7 @@ import sys
 
 from anki.lang import _
 from aqt.qt import *
-from aqt.qt import QMenu
+from aqt.qt import QMenu, qtmajor
 
 from aqt import mw
 from aqt.editor import Editor, EditorWebView
@@ -151,8 +151,12 @@ def openImage(path):
 
 
 def maybe_add_image_menu(webview: AnkiWebView, menu: QMenu):
-    # cf. https://doc.qt.io/qt-5/qwebenginepage.html#contextMenuData
-    context_data = webview.page().contextMenuData()
+    if qtmajor == 5:
+        # cf. https://doc.qt.io/qt-5/qwebenginepage.html#contextMenuData
+        context_data = webview.page().contextMenuData()
+    else:
+        # https://doc.qt.io/qt-6/qwebenginecontextmenurequest.html
+        context_data = webview.lastContextMenuRequest()
     url = context_data.mediaUrl()
     image_name = url.fileName()
     path = os.path.join(mw.col.media.dir(), image_name)


### PR DESCRIPTION
#### Description

In Qt6, context menu is not handled by QWebEnginePage anymore.
https://doc.qt.io/qt-6/qwebenginecontextmenurequest.html

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Anki v2.1.50, running from source (26d40c3a8)
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bookworm
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
