### PR TITLE
Fix error caused by missing cleanup() call

### DIFF
--- a/src/image_occlusion_enhanced/editor.py
+++ b/src/image_occlusion_enhanced/editor.py
@@ -141,6 +141,9 @@ class ImgOccEdit(QDialog):
             addHook("unloadProfile", self.onProfileUnload)
 
     def closeEvent(self, event):
+        self._on_close()
+
+    def _on_close(self):
         if mw.pm.profile is not None:
             self.deckChooser.cleanup()
             saveGeom(self, "imgoccedit")
@@ -172,7 +175,7 @@ class ImgOccEdit(QDialog):
             " changes.",
             title="Exit Image Occlusion?",
         ):
-            return super().reject()
+            self._on_close()
 
     def _input_modified(self) -> bool:
         tags_modified = self.tags_edit.isModified()


### PR DESCRIPTION
#### Description

A missing call to deckchooser.cleanup() in reject() was throwing "wrapped C/C++ object of type QPushButton has been deleted" when mw.reset() is called.

Relevant: https://forums.ankiweb.net/t/mw-reset-throwing-wrapped-c-c-object-of-type-qpushbutton-has-been-deleted/16420

This also potentially addresses issues handled by other code in closeEvent (if it was meant to be executed when the dialog is rejected too).

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [x] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
