### PR TITLE
[251] Call webview.cleanup() on 2.1.50+ and up, de-registering theme change handler

### DIFF
--- a/src/image_occlusion_enhanced/editor.py
+++ b/src/image_occlusion_enhanced/editor.py
@@ -148,6 +148,8 @@ class ImgOccEdit(QDialog):
             self.deckChooser.cleanup()
             saveGeom(self, "imgoccedit")
         self.visible = False
+        if hasattr(self.svg_edit, "cleanup"):  # 2.1.50+
+            self.svg_edit.cleanup()  # type: ignore
         self.svg_edit = None
         del self.svg_edit_anim  # might not be gc'd
         try:


### PR DESCRIPTION
Fixes #251 